### PR TITLE
fix: unify microphone discovery with CoreAudio

### DIFF
--- a/Sources/OpenScribe/Core/AudioCaptureManager.swift
+++ b/Sources/OpenScribe/Core/AudioCaptureManager.swift
@@ -47,12 +47,18 @@ final class AudioCaptureManager {
 
         let inputNode = freshEngine.inputNode
         let inputFormat = inputNode.inputFormat(forBus: 0)
+        guard inputFormat.channelCount > 0, inputFormat.sampleRate > 0 else {
+            throw ProviderError.unsupported("The selected microphone returned an invalid input format.")
+        }
 
         guard let targetFormat = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: 16_000, channels: 1, interleaved: true) else {
             throw ProviderError.unsupported("Failed to create output audio format.")
         }
 
-        converter = AVAudioConverter(from: inputFormat, to: targetFormat)
+        guard let converter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
+            throw ProviderError.unsupported("Failed to prepare audio conversion for the selected microphone.")
+        }
+        self.converter = converter
         wavWriter = try WavFileWriter(
             url: tempURL,
             sampleRate: Int(targetFormat.sampleRate),
@@ -66,7 +72,14 @@ final class AudioCaptureManager {
         }
 
         freshEngine.prepare()
-        try freshEngine.start()
+        do {
+            try freshEngine.start()
+        } catch {
+            let selectedInputDescription = inputDeviceID ?? "system default input"
+            throw ProviderError.unsupported(
+                "Unable to start audio capture on \(selectedInputDescription): \(error.localizedDescription)"
+            )
+        }
         engine = freshEngine
     }
 
@@ -160,7 +173,7 @@ final class AudioCaptureManager {
             throw ProviderError.unsupported("Unable to access audio input unit.")
         }
 
-        guard let coreAudioDeviceID = coreAudioInputDeviceID(for: inputDeviceID) else {
+        guard let coreAudioDeviceID = CoreAudioMicrophoneCatalog.audioDeviceID(for: inputDeviceID) else {
             throw ProviderError.unsupported("Selected microphone is unavailable.")
         }
 
@@ -175,96 +188,10 @@ final class AudioCaptureManager {
         )
 
         guard status == noErr else {
-            throw ProviderError.unsupported("Unable to select the requested microphone.")
-        }
-    }
-
-    private func coreAudioInputDeviceID(for uniqueID: String) -> AudioDeviceID? {
-        let deviceIDs = allAudioDeviceIDs()
-        guard !deviceIDs.isEmpty else {
-            return nil
-        }
-
-        for deviceID in deviceIDs {
-            guard let candidateUID = coreAudioDeviceUID(for: deviceID) else {
-                continue
-            }
-
-            if candidateUID == uniqueID {
-                return deviceID
-            }
-        }
-
-        return nil
-    }
-
-    private func allAudioDeviceIDs() -> [AudioDeviceID] {
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDevices,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-
-        var dataSize: UInt32 = 0
-        let sizeStatus = AudioObjectGetPropertyDataSize(
-            AudioObjectID(kAudioObjectSystemObject),
-            &propertyAddress,
-            0,
-            nil,
-            &dataSize
-        )
-        guard sizeStatus == noErr, dataSize > 0 else {
-            return []
-        }
-
-        let count = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
-        var deviceIDs = Array(repeating: AudioDeviceID(0), count: count)
-
-        let dataStatus: OSStatus = deviceIDs.withUnsafeMutableBufferPointer { buffer in
-            guard let baseAddress = buffer.baseAddress else {
-                return -1
-            }
-
-            return AudioObjectGetPropertyData(
-                AudioObjectID(kAudioObjectSystemObject),
-                &propertyAddress,
-                0,
-                nil,
-                &dataSize,
-                baseAddress
+            throw ProviderError.unsupported(
+                "Unable to select the requested microphone (OSStatus \(status))."
             )
         }
-        guard dataStatus == noErr else {
-            return []
-        }
-
-        return deviceIDs
-    }
-
-    private func coreAudioDeviceUID(for deviceID: AudioDeviceID) -> String? {
-        var propertyAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyDeviceUID,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-
-        var dataSize = UInt32(MemoryLayout<CFString>.size)
-        var uid: CFString = "" as CFString
-        let status: OSStatus = withUnsafeMutablePointer(to: &uid) { uidPointer in
-            AudioObjectGetPropertyData(
-                deviceID,
-                &propertyAddress,
-                0,
-                nil,
-                &dataSize,
-                uidPointer
-            )
-        }
-        guard status == noErr else {
-            return nil
-        }
-
-        return uid as String
     }
 }
 

--- a/Sources/OpenScribe/Core/CoreAudioMicrophoneCatalog.swift
+++ b/Sources/OpenScribe/Core/CoreAudioMicrophoneCatalog.swift
@@ -1,0 +1,214 @@
+import CoreAudio
+import Foundation
+
+enum CoreAudioMicrophoneCatalog {
+    private static let systemObjectID = AudioObjectID(kAudioObjectSystemObject)
+
+    struct Device: Equatable {
+        let id: AudioDeviceID
+        let uid: String
+        let name: String
+    }
+
+    static func currentSnapshot() -> MicrophoneDeviceSnapshot {
+        let devices = inputDevices()
+        let defaultInputDeviceID = defaultInputDeviceID()
+
+        return MicrophoneDeviceSnapshot(
+            devices: devices
+                .map { MicrophoneDevice(id: $0.uid, name: $0.name) }
+                .sorted { lhs, rhs in
+                    lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+                },
+            systemDefaultDeviceID: defaultInputDeviceID.flatMap(deviceUID(for:)),
+            systemDefaultDeviceName: defaultInputDeviceID.flatMap(deviceName(for:))
+        )
+    }
+
+    static func audioDeviceID(for uid: String) -> AudioDeviceID? {
+        inputDevices().first(where: { $0.uid == uid })?.id
+    }
+
+    static func propertyAddressesToObserve() -> [AudioObjectPropertyAddress] {
+        [
+            AudioObjectPropertyAddress(
+                mSelector: kAudioHardwarePropertyDevices,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            ),
+            AudioObjectPropertyAddress(
+                mSelector: kAudioHardwarePropertyDefaultInputDevice,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+        ]
+    }
+
+    private static func inputDevices() -> [Device] {
+        allAudioDeviceIDs().compactMap { deviceID in
+            guard deviceHasInputChannels(deviceID),
+                  let uid = deviceUID(for: deviceID),
+                  let name = deviceName(for: deviceID) else {
+                return nil
+            }
+
+            return Device(id: deviceID, uid: uid, name: name)
+        }
+    }
+
+    private static func defaultInputDeviceID() -> AudioDeviceID? {
+        var propertyAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        var deviceID = AudioDeviceID(0)
+        var dataSize = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioObjectGetPropertyData(
+            systemObjectID,
+            &propertyAddress,
+            0,
+            nil,
+            &dataSize,
+            &deviceID
+        )
+
+        guard status == noErr, deviceID != 0 else {
+            return nil
+        }
+
+        return deviceID
+    }
+
+    private static func allAudioDeviceIDs() -> [AudioDeviceID] {
+        var propertyAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        var dataSize: UInt32 = 0
+        let sizeStatus = AudioObjectGetPropertyDataSize(
+            systemObjectID,
+            &propertyAddress,
+            0,
+            nil,
+            &dataSize
+        )
+        guard sizeStatus == noErr, dataSize > 0 else {
+            return []
+        }
+
+        let count = Int(dataSize) / MemoryLayout<AudioDeviceID>.size
+        var deviceIDs = Array(repeating: AudioDeviceID(0), count: count)
+
+        let dataStatus: OSStatus = deviceIDs.withUnsafeMutableBufferPointer { buffer in
+            guard let baseAddress = buffer.baseAddress else {
+                return kAudioHardwareUnspecifiedError
+            }
+
+            return AudioObjectGetPropertyData(
+                systemObjectID,
+                &propertyAddress,
+                0,
+                nil,
+                &dataSize,
+                baseAddress
+            )
+        }
+        guard dataStatus == noErr else {
+            return []
+        }
+
+        return deviceIDs
+    }
+
+    private static func deviceHasInputChannels(_ deviceID: AudioDeviceID) -> Bool {
+        var propertyAddress = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        var dataSize: UInt32 = 0
+        let sizeStatus = AudioObjectGetPropertyDataSize(
+            deviceID,
+            &propertyAddress,
+            0,
+            nil,
+            &dataSize
+        )
+        guard sizeStatus == noErr, dataSize >= UInt32(MemoryLayout<AudioBufferList>.size) else {
+            return false
+        }
+
+        let rawBuffer = UnsafeMutableRawPointer.allocate(
+            byteCount: Int(dataSize),
+            alignment: MemoryLayout<AudioBufferList>.alignment
+        )
+        defer { rawBuffer.deallocate() }
+
+        let dataStatus = AudioObjectGetPropertyData(
+            deviceID,
+            &propertyAddress,
+            0,
+            nil,
+            &dataSize,
+            rawBuffer
+        )
+        guard dataStatus == noErr else {
+            return false
+        }
+
+        let audioBufferList = rawBuffer.assumingMemoryBound(to: AudioBufferList.self)
+        let bufferList = UnsafeMutableAudioBufferListPointer(audioBufferList)
+        return bufferList.contains(where: { $0.mNumberChannels > 0 })
+    }
+
+    private static func deviceUID(for deviceID: AudioDeviceID) -> String? {
+        propertyString(
+            objectID: deviceID,
+            selector: kAudioDevicePropertyDeviceUID,
+            scope: kAudioObjectPropertyScopeGlobal
+        )
+    }
+
+    private static func deviceName(for deviceID: AudioDeviceID) -> String? {
+        propertyString(
+            objectID: deviceID,
+            selector: kAudioObjectPropertyName,
+            scope: kAudioObjectPropertyScopeGlobal
+        )
+    }
+
+    private static func propertyString(
+        objectID: AudioObjectID,
+        selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope
+    ) -> String? {
+        var propertyAddress = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: scope,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        var dataSize = UInt32(MemoryLayout<CFString>.size)
+        var value: CFString = "" as CFString
+        let status = withUnsafeMutablePointer(to: &value) { valuePointer in
+            AudioObjectGetPropertyData(
+                objectID,
+                &propertyAddress,
+                0,
+                nil,
+                &dataSize,
+                valuePointer
+            )
+        }
+        guard status == noErr else {
+            return nil
+        }
+
+        return value as String
+    }
+}

--- a/Sources/OpenScribe/Core/MicrophoneDeviceCatalog.swift
+++ b/Sources/OpenScribe/Core/MicrophoneDeviceCatalog.swift
@@ -1,4 +1,4 @@
-@preconcurrency import AVFoundation
+import CoreAudio
 import Foundation
 
 protocol MicrophoneDeviceCatalogProtocol: AnyObject {
@@ -6,59 +6,61 @@ protocol MicrophoneDeviceCatalogProtocol: AnyObject {
     func currentSnapshot() -> MicrophoneDeviceSnapshot
 }
 
-final class MicrophoneDeviceCatalog: NSObject, MicrophoneDeviceCatalogProtocol {
+final class MicrophoneDeviceCatalog: MicrophoneDeviceCatalogProtocol {
     var onSnapshotChange: ((MicrophoneDeviceSnapshot) -> Void)?
 
-    private let notificationCenter: NotificationCenter
+    private final class ListenerRelay {
+        weak var owner: MicrophoneDeviceCatalog?
 
-    init(notificationCenter: NotificationCenter = .default) {
-        self.notificationCenter = notificationCenter
-        super.init()
+        func publishSnapshot() {
+            owner?.publishSnapshot()
+        }
+    }
+
+    private let listenerQueue: DispatchQueue
+    private let systemObjectID = AudioObjectID(kAudioObjectSystemObject)
+    private let listenerRelay: ListenerRelay
+    private let propertyListener: AudioObjectPropertyListenerBlock
+
+    init(listenerQueue: DispatchQueue = .main) {
+        let listenerRelay = ListenerRelay()
+        self.listenerQueue = listenerQueue
+        self.listenerRelay = listenerRelay
+        self.propertyListener = { [weak listenerRelay] _, _ in
+            listenerRelay?.publishSnapshot()
+        }
+        listenerRelay.owner = self
         registerForDeviceChanges()
     }
 
     deinit {
-        notificationCenter.removeObserver(self)
+        unregisterForDeviceChanges()
     }
 
     func currentSnapshot() -> MicrophoneDeviceSnapshot {
-        let discoverySession = AVCaptureDevice.DiscoverySession(
-            deviceTypes: [.microphone],
-            mediaType: .audio,
-            position: .unspecified
-        )
-        let devices = discoverySession.devices
-            .map { MicrophoneDevice(id: $0.uniqueID, name: $0.localizedName) }
-            .sorted { lhs, rhs in
-                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
-            }
-
-        let systemDefault = AVCaptureDevice.default(for: .audio)
-        return MicrophoneDeviceSnapshot(
-            devices: devices,
-            systemDefaultDeviceID: systemDefault?.uniqueID,
-            systemDefaultDeviceName: systemDefault?.localizedName
-        )
+        CoreAudioMicrophoneCatalog.currentSnapshot()
     }
 
     private func registerForDeviceChanges() {
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(handleDeviceChange),
-            name: AVCaptureDevice.wasConnectedNotification,
-            object: nil
-        )
-        notificationCenter.addObserver(
-            self,
-            selector: #selector(handleDeviceChange),
-            name: AVCaptureDevice.wasDisconnectedNotification,
-            object: nil
-        )
+        for var propertyAddress in CoreAudioMicrophoneCatalog.propertyAddressesToObserve() {
+            AudioObjectAddPropertyListenerBlock(
+                systemObjectID,
+                &propertyAddress,
+                listenerQueue,
+                propertyListener
+            )
+        }
     }
 
-    @objc
-    private func handleDeviceChange(_ notification: Notification) {
-        publishSnapshot()
+    private func unregisterForDeviceChanges() {
+        for var propertyAddress in CoreAudioMicrophoneCatalog.propertyAddressesToObserve() {
+            AudioObjectRemovePropertyListenerBlock(
+                systemObjectID,
+                &propertyAddress,
+                listenerQueue,
+                propertyListener
+            )
+        }
     }
 
     private func publishSnapshot() {

--- a/Sources/OpenScribe/Core/MicrophoneSelection.swift
+++ b/Sources/OpenScribe/Core/MicrophoneSelection.swift
@@ -15,6 +15,7 @@ enum MicrophoneResolutionSource: Equatable {
     case pinned
     case sessionOverride
     case systemDefault
+    case firstAvailable
     case unavailable
 }
 
@@ -62,7 +63,7 @@ enum MicrophoneSelectionResolver {
             if let firstDevice = snapshot.devices.first {
                 return MicrophoneResolutionResult(
                     device: firstDevice,
-                    source: .systemDefault,
+                    source: .firstAvailable,
                     statusMessage: "Pinned mic \"\(pinnedMicrophone.name)\" unavailable. Using available input \"\(firstDevice.name)\"."
                 )
             }
@@ -86,7 +87,7 @@ enum MicrophoneSelectionResolver {
         if let firstDevice = snapshot.devices.first {
             return MicrophoneResolutionResult(
                 device: firstDevice,
-                source: .systemDefault,
+                source: .firstAvailable,
                 statusMessage: nil
             )
         }
@@ -109,7 +110,7 @@ enum MicrophoneCaptureRouting {
         }
 
         switch resolution.source {
-        case .sessionOverride, .pinned:
+        case .sessionOverride, .pinned, .firstAvailable:
             if selectedDeviceID == systemDefaultDeviceID {
                 return nil
             }

--- a/Tests/OpenScribeTests/AudioCaptureManagerLiveTests.swift
+++ b/Tests/OpenScribeTests/AudioCaptureManagerLiveTests.swift
@@ -1,4 +1,3 @@
-@preconcurrency import AVFoundation
 import Foundation
 import XCTest
 @testable import OpenScribe
@@ -55,7 +54,10 @@ final class AudioCaptureManagerLiveTests: XCTestCase {
            !configuredID.isEmpty {
             targetID = configuredID
         } else {
-            targetID = AVCaptureDevice.default(for: .audio)?.uniqueID
+            let snapshot = CoreAudioMicrophoneCatalog.currentSnapshot()
+            targetID = snapshot.devices
+                .first(where: { $0.id != snapshot.systemDefaultDeviceID })?
+                .id ?? snapshot.systemDefaultDeviceID
         }
 
         guard let targetID else {

--- a/Tests/OpenScribeTests/MicrophoneSelectionResolverTests.swift
+++ b/Tests/OpenScribeTests/MicrophoneSelectionResolverTests.swift
@@ -104,6 +104,27 @@ final class MicrophoneSelectionResolverTests: XCTestCase {
         XCTAssertEqual(result.statusMessage, "Pinned mic \"Desk Mic\" unavailable and no microphone input is currently available.")
     }
 
+    func testMissingSystemDefaultFallsBackToFirstAvailable() {
+        let snapshot = MicrophoneDeviceSnapshot(
+            devices: [
+                MicrophoneDevice(id: "usb", name: "USB Mic"),
+                MicrophoneDevice(id: "builtin", name: "Built-in Mic")
+            ],
+            systemDefaultDeviceID: nil,
+            systemDefaultDeviceName: nil
+        )
+
+        let result = MicrophoneSelectionResolver.resolve(
+            snapshot: snapshot,
+            pinnedMicrophone: nil,
+            sessionOverrideID: nil
+        )
+
+        XCTAssertEqual(result.source, .firstAvailable)
+        XCTAssertEqual(result.device?.id, "usb")
+        XCTAssertNil(result.statusMessage)
+    }
+
     func testCaptureRoutingReturnsNilForAutomaticSystemDefault() {
         let resolution = MicrophoneResolutionResult(
             device: MicrophoneDevice(id: "builtin", name: "Built-in Mic"),
@@ -147,5 +168,20 @@ final class MicrophoneSelectionResolverTests: XCTestCase {
         )
 
         XCTAssertNil(inputDeviceID)
+    }
+
+    func testCaptureRoutingReturnsExplicitIDForFirstAvailableFallback() {
+        let resolution = MicrophoneResolutionResult(
+            device: MicrophoneDevice(id: "usb", name: "USB Mic"),
+            source: .firstAvailable,
+            statusMessage: nil
+        )
+
+        let inputDeviceID = MicrophoneCaptureRouting.inputDeviceIDForCapture(
+            resolution: resolution,
+            systemDefaultDeviceID: "builtin"
+        )
+
+        XCTAssertEqual(inputDeviceID, "usb")
     }
 }


### PR DESCRIPTION
Why
- Mixed AVCapture and CoreAudio microphone identity paths could fail on some Macs.
- First available fallback could select one input in UI and another in capture.

What
- Add a shared CoreAudio microphone catalog for device listing and default input lookup.
- Route microphone catalog refresh and capture selection through the same CoreAudio identifiers.
- Distinguish first available fallback from system default and cover it in tests.

Instruction
- Implement the proper audio stability fix, stage it, commit it, and push after review.

## Contribution Policy

OpenScribe uses an issue-first contribution model.

- External contributors should open a work issue with acceptance criteria.
- Maintainer and Scribe create implementation pull requests for accepted work.
- External pull requests may be closed and redirected to issues.

Related issue:

- Closes #
