### PR TITLE
feat: add cerebras polish provider

### DIFF
--- a/Sources/OpenScribe/AppShell/AppShell.swift
+++ b/Sources/OpenScribe/AppShell/AppShell.swift
@@ -19,6 +19,7 @@ enum ProviderBackend: String {
     case groq
     case openrouter
     case gemini
+    case cerebras
 
     var displayName: String {
         switch self {
@@ -32,6 +33,8 @@ enum ProviderBackend: String {
             return "OpenRouter"
         case .gemini:
             return "Gemini"
+        case .cerebras:
+            return "Cerebras"
         }
     }
 
@@ -135,6 +138,7 @@ final class AppShell: ObservableObject {
     @Published var groqKeyInput: String = ""
     @Published var openRouterKeyInput: String = ""
     @Published var geminiKeyInput: String = ""
+    @Published var cerebrasKeyInput: String = ""
     @Published var latestPolishedTranscript: String = ""
     @Published var transcribeElapsedSeconds: Int = 0
     @Published var polishElapsedSeconds: Int = 0
@@ -228,6 +232,7 @@ final class AppShell: ObservableObject {
         self.groqKeyInput = keychainStore.load(.groq) ?? ""
         self.openRouterKeyInput = keychainStore.load(.openRouter) ?? ""
         self.geminiKeyInput = keychainStore.load(.gemini) ?? ""
+        self.cerebrasKeyInput = keychainStore.load(.cerebras) ?? ""
 
         audioCapture.onLevelUpdate = { [audioMeter] level in
             Task { @MainActor in
@@ -273,6 +278,10 @@ final class AppShell: ObservableObject {
 
     var geminiKeyStatusDescription: String {
         apiKeyStatusDescription(for: .gemini)
+    }
+
+    var cerebrasKeyStatusDescription: String {
+        apiKeyStatusDescription(for: .cerebras)
     }
 
     var accessibilityPermissionGranted: Bool {
@@ -445,6 +454,13 @@ final class AppShell: ObservableObject {
             try? keychainStore.save(gemini, for: .gemini)
         }
 
+        let cerebras = cerebrasKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        if cerebras.isEmpty {
+            keychainStore.delete(.cerebras)
+        } else {
+            try? keychainStore.save(cerebras, for: .cerebras)
+        }
+
         statusMessage = "API keys saved"
     }
 
@@ -458,6 +474,8 @@ final class AppShell: ObservableObject {
             openRouterKeyInput = ""
         case .gemini:
             geminiKeyInput = ""
+        case .cerebras:
+            cerebrasKeyInput = ""
         }
         saveAPIKeys()
     }
@@ -467,6 +485,7 @@ final class AppShell: ObservableObject {
         groqKeyInput = ""
         openRouterKeyInput = ""
         geminiKeyInput = ""
+        cerebrasKeyInput = ""
         saveAPIKeys()
         statusMessage = "API keys cleared"
     }
@@ -1379,6 +1398,8 @@ final class AppShell: ObservableObject {
             return ["openai/gpt-5-nano", "openai/gpt-5-mini", "google/gemini-2.5-flash"]
         case ("gemini_polish", .polish):
             return ["gemini-2.5-flash"]
+        case ("cerebras_polish", .polish):
+            return ["gpt-oss-120b"]
         case (_, .transcription):
             return ["base"]
         case (_, .polish):
@@ -1446,7 +1467,8 @@ final class AppShell: ObservableObject {
             (.openAI, "openai_whisper"),
             (.groq, "groq_whisper"),
             (.openRouter, "openrouter_transcribe"),
-            (.gemini, "gemini_transcribe")
+            (.gemini, "gemini_transcribe"),
+            (.cerebras, "cerebras_polish")
         ]
 
         for (entry, providerID) in verificationPlan {
@@ -1577,6 +1599,8 @@ final class AppShell: ObservableObject {
             return .openrouter
         case "gemini_transcribe", "gemini_polish":
             return .gemini
+        case "cerebras_polish":
+            return .cerebras
         default:
             return nil
         }
@@ -1606,7 +1630,7 @@ final class AppShell: ObservableObject {
         case (.groq, .polish):
             let filtered = models.filter { !$0.lowercased().contains("whisper") }
             return filtered.sorted()
-        case (.whispercpp, _), (.openrouter, _), (.gemini, _):
+        case (.whispercpp, _), (.openrouter, _), (.gemini, _), (.cerebras, _):
             return models.sorted()
         }
     }
@@ -1618,6 +1642,8 @@ final class AppShell: ObservableObject {
         switch (providerID, usage) {
         case ("groq_polish", .polish):
             return "openai/gpt-oss-120b"
+        case ("cerebras_polish", .polish):
+            return "gpt-oss-120b"
         default:
             return nil
         }
@@ -1652,6 +1678,13 @@ final class AppShell: ObservableObject {
             let key = apiKeyResolver.resolve(.gemini).value
             guard let key else { throw ProviderError.missingAPIKey("Gemini") }
             return try await fetchGeminiModels(apiKey: key)
+        case .cerebras:
+            let key = apiKeyResolver.resolve(.cerebras).value
+            guard let key else { throw ProviderError.missingAPIKey("Cerebras") }
+            return try await fetchOpenAICompatibleModels(
+                endpoint: URL(string: "https://api.cerebras.ai/v1/models")!,
+                apiKey: key
+            )
         }
     }
 

--- a/Sources/OpenScribe/Core/Models.swift
+++ b/Sources/OpenScribe/Core/Models.swift
@@ -247,6 +247,7 @@ enum KeychainEntry: String {
     case groq = "groq_api_key"
     case openRouter = "openrouter_api_key"
     case gemini = "gemini_api_key"
+    case cerebras = "cerebras_api_key"
 
     var providerDisplayName: String {
         switch self {
@@ -258,6 +259,8 @@ enum KeychainEntry: String {
             return "OpenRouter"
         case .gemini:
             return "Gemini"
+        case .cerebras:
+            return "Cerebras"
         }
     }
 }

--- a/Sources/OpenScribe/Providers/CerebrasPolishProvider.swift
+++ b/Sources/OpenScribe/Providers/CerebrasPolishProvider.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+final class CerebrasPolishProvider: PolishProvider {
+    let id = "cerebras_polish"
+    let displayName = "Cerebras Polish"
+
+    private let apiKey: String
+    private let endpoint = URL(string: "https://api.cerebras.ai/v1/chat/completions")!
+
+    init(apiKey: String) {
+        self.apiKey = apiKey
+    }
+
+    func polish(rawText: String, rulesMarkdown: String, model: String, instruction: String?) async throws -> PolishResult {
+        let start = Date()
+        let response = try await performChatRequest(
+            endpoint: endpoint,
+            apiKey: apiKey,
+            model: model,
+            systemPrompt: instruction,
+            userPrompt: makePolishUserPrompt(rawText: rawText, rulesMarkdown: rulesMarkdown)
+        )
+        let polished = sanitizePolishedOutput(unwrapCodeBlockIfNeeded(response.text), rawText: rawText)
+
+        return PolishResult(
+            markdown: polished,
+            providerId: id,
+            model: model,
+            latencyMs: Int(Date().timeIntervalSince(start) * 1_000),
+            inputTokens: response.inputTokens,
+            outputTokens: response.outputTokens
+        )
+    }
+}

--- a/Sources/OpenScribe/Providers/ProviderFactory.swift
+++ b/Sources/OpenScribe/Providers/ProviderFactory.swift
@@ -62,6 +62,11 @@ final class ProviderFactory {
                 throw ProviderError.missingAPIKey("Gemini")
             }
             return GeminiPolishProvider(apiKey: key)
+        case "cerebras_polish":
+            guard let key = apiKeyResolver.resolve(.cerebras).value else {
+                throw ProviderError.missingAPIKey("Cerebras")
+            }
+            return CerebrasPolishProvider(apiKey: key)
         default:
             throw ProviderError.unsupported("Unknown polish provider: \(id)")
         }

--- a/Sources/OpenScribe/UI/PopoverView.swift
+++ b/Sources/OpenScribe/UI/PopoverView.swift
@@ -1489,6 +1489,11 @@ struct PopoverView: View {
             providerName: "Gemini",
             models: shell.availableModels(for: "gemini_polish", usage: .polish)
         ))
+        options.append(contentsOf: verifiedOptions(
+            providerID: "cerebras_polish",
+            providerName: "Cerebras",
+            models: shell.availableModels(for: "cerebras_polish", usage: .polish)
+        ))
 
         if options.isEmpty {
             options = [RetryModelOption(
@@ -1604,6 +1609,8 @@ struct PopoverView: View {
             return "OpenRouter"
         case "gemini_polish":
             return "Gemini"
+        case "cerebras_polish":
+            return "Cerebras"
         default:
             return providerID
         }

--- a/Sources/OpenScribe/UI/SettingsView.swift
+++ b/Sources/OpenScribe/UI/SettingsView.swift
@@ -159,7 +159,8 @@ struct SettingsView: View {
         (id: "openai_polish", label: "OpenAI"),
         (id: "groq_polish", label: "Groq"),
         (id: "openrouter_polish", label: "OpenRouter"),
-        (id: "gemini_polish", label: "Gemini")
+        (id: "gemini_polish", label: "Gemini"),
+        (id: "cerebras_polish", label: "Cerebras")
     ]
     private let authorGitHubURL = URL(string: "https://github.com/streichsbaer")!
     private let authorXURL = URL(string: "https://x.com/s_streichsbier")!
@@ -542,6 +543,18 @@ struct SettingsView: View {
                     providerID: "gemini_polish"
                 ) {
                     shell.clearAPIKey(.gemini)
+                }
+
+                sectionDivider()
+
+                providerKeySection(
+                    title: "Cerebras",
+                    placeholder: "Cerebras API key",
+                    keyText: $shell.cerebrasKeyInput,
+                    statusDescription: shell.cerebrasKeyStatusDescription,
+                    providerID: "cerebras_polish"
+                ) {
+                    shell.clearAPIKey(.cerebras)
                 }
 
                 HStack(spacing: 8) {

--- a/Tests/OpenScribeTests/APIKeyResolverTests.swift
+++ b/Tests/OpenScribeTests/APIKeyResolverTests.swift
@@ -12,7 +12,7 @@ final class APIKeyResolverTests: XCTestCase {
     }
 
     override func tearDown() {
-        for entry in [KeychainEntry.openAI, .groq, .openRouter, .gemini] {
+        for entry in [KeychainEntry.openAI, .groq, .openRouter, .gemini, .cerebras] {
             keychain.delete(entry)
         }
         keychain = nil

--- a/Tests/OpenScribeTests/AppShellFallbackModelsTests.swift
+++ b/Tests/OpenScribeTests/AppShellFallbackModelsTests.swift
@@ -30,4 +30,27 @@ final class AppShellFallbackModelsTests: XCTestCase {
             ["allam-2-7b", "groq/compound", "llama-3.3-70b-versatile"]
         )
     }
+
+    func testCerebrasPolishFallbackModelsPreferRecommendedModel() {
+        let models = AppShell.fallbackModels(for: "cerebras_polish", usage: .polish)
+
+        XCTAssertEqual(models, ["gpt-oss-120b"])
+    }
+
+    func testCerebrasPolishFetchedCatalogStillPrefersRecommendedModel() {
+        let models = [
+            "llama3.1-8b",
+            "gpt-oss-120b",
+            "qwen-3-32b"
+        ]
+
+        let ordered = AppShell.prioritizeRecommendedModel(
+            models,
+            providerID: "cerebras_polish",
+            usage: .polish
+        )
+
+        XCTAssertEqual(ordered.first, "gpt-oss-120b")
+        XCTAssertEqual(Array(ordered.dropFirst()), ["llama3.1-8b", "qwen-3-32b"])
+    }
 }

--- a/Tests/OpenScribeTests/KeychainEntryTests.swift
+++ b/Tests/OpenScribeTests/KeychainEntryTests.swift
@@ -7,5 +7,6 @@ final class KeychainEntryTests: XCTestCase {
         XCTAssertEqual(KeychainEntry.groq.providerDisplayName, "Groq")
         XCTAssertEqual(KeychainEntry.openRouter.providerDisplayName, "OpenRouter")
         XCTAssertEqual(KeychainEntry.gemini.providerDisplayName, "Gemini")
+        XCTAssertEqual(KeychainEntry.cerebras.providerDisplayName, "Cerebras")
     }
 }

--- a/Tests/OpenScribeTests/LiveProviderSmokeTests.swift
+++ b/Tests/OpenScribeTests/LiveProviderSmokeTests.swift
@@ -98,6 +98,8 @@ final class LiveProviderSmokeTests: XCTestCase {
             return OpenRouterPolishProvider(apiKey: try apiKey(for: .openRouter))
         case "gemini_polish":
             return GeminiPolishProvider(apiKey: try apiKey(for: .gemini))
+        case "cerebras_polish":
+            return CerebrasPolishProvider(apiKey: try apiKey(for: .cerebras))
         default:
             throw ProviderError.unsupported("Unsupported live smoke polish provider: \(id)")
         }

--- a/site-docs/guides/providers.md
+++ b/site-docs/guides/providers.md
@@ -36,6 +36,7 @@ Polish runs a language model on your raw transcript to improve grammar, formatti
 - **Groq** -- recommended cloud polish path with `openai/gpt-oss-120b`.
 - **OpenRouter** -- access to multiple model providers through one API key.
 - **Gemini** -- Google models that can cover transcription and polish, but they are not the recommended polish path.
+- **Cerebras** -- OpenAI-compatible chat API with `gpt-oss-120b` as a strong default polish model.
 
 Polish is disabled by default. Enable it in Settings > Polish.
 

--- a/site-docs/reference/ui-reference.md
+++ b/site-docs/reference/ui-reference.md
@@ -85,7 +85,7 @@ You can open Settings from the right-click menu, with `Cmd + ,` when OpenScribe 
 
 ### Providers
 
-- API key management for OpenAI, Groq, OpenRouter, and Gemini.
+- API key management for OpenAI, Groq, OpenRouter, Gemini, and Cerebras.
 - Verify the current token for each provider.
 - Refresh shared provider model lists used by Transcribe and Polish.
 


### PR DESCRIPTION
## Summary
- add a Cerebras polish provider on the OpenAI compatible chat completions path
- wire Cerebras into key storage, model verification, settings, retry options, and docs
- add fallback model and live smoke coverage for `cerebras_polish`

## Verification
- `swift build`
- `swift test`
- `RUN_AUDIO_FIXTURE_TESTS=1 swift test --filter FixturePipelineTests`
- `zsh .agents/skills/ui-smoke/scripts/run.sh --out artifacts/ui-smoke/latest`
- `RUN_LIVE_PROVIDER_SMOKE=1 LIVE_SMOKE_STT_PROVIDER=groq_whisper LIVE_SMOKE_STT_MODEL=whisper-large-v3-turbo LIVE_SMOKE_POLISH_PROVIDER=cerebras_polish LIVE_SMOKE_POLISH_MODEL=gpt-oss-120b swift test --filter LiveProviderSmokeTests`
